### PR TITLE
Feature/add config and deletion tree handlers

### DIFF
--- a/src/cleaning/mod.rs
+++ b/src/cleaning/mod.rs
@@ -1,2 +1,46 @@
 mod mark_for_deletion;
 pub mod track_files_for_deletion;
+
+use crate::configs::config::PathConfig;
+use crate::logging::deletion_overview::generate_deletion_overview_text;
+use crate::logging::folder_tree_helpers::DirTreeOptions;
+use crate::logging::process_directory_tree::{process_folder_tree_stack, FileSystemStack};
+use track_files_for_deletion::track_files_for_deletion;
+
+// TODO: Adjust DirTreeOptions
+/// Processes a given configuration to track files for deletion and generate a deletion overview.
+///
+/// # Arguments
+///
+/// * `config` - A reference to a `PathConfig` that specifies the configuration for file deletion.
+///
+/// # Returns
+///
+/// * `Ok(String)` - A string representing the deletion overview if the operation is successful.
+/// * `Err(std::io::Error)` - An error if tracking files for deletion fails.
+pub fn process_config(config: &PathConfig) -> Result<(String, FileSystemStack), std::io::Error> {
+    let files_for_deletion = track_files_for_deletion(config);
+
+    match files_for_deletion {
+        Ok((deletion_queue, deletion_metadata)) => {
+            let deletion_overview =
+                generate_deletion_overview_text(config, deletion_metadata, &config.display_units);
+            return Ok((deletion_overview, deletion_queue));
+        }
+        Err(e) => {
+            eprintln!("Error tracking files for deletion: {}", e);
+            return Err(e);
+        }
+    }
+}
+
+/// Prints a deletion tree for a given file system stack.
+///
+/// # Arguments
+///
+/// * `deletion_queue` - A `FileSystemStack` that represents the file system stack for deletion.
+pub fn print_deletion_tree(deletion_queue: FileSystemStack) {
+    let options = DirTreeOptions::default();
+    let deletion_tree = process_folder_tree_stack(deletion_queue, &options);
+    println!("{}", deletion_tree);
+}

--- a/src/cli_tools/cleaner_cli.rs
+++ b/src/cli_tools/cleaner_cli.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+
+/// Cleans up folders based on a given path or configuration file.
+#[derive(Parser)]
+#[command(
+    name = "folder_cleaner",
+    about = "A safer file cleaner. Generate detailed insights \
+        about your folder(s), so you can avoid accidentally deleting data.",
+    version = "1.0"
+)]
+pub struct CleanerCLI {
+    /// The path to clean or a configuration key to use.
+    #[arg(required_unless_present_any = &["config"], conflicts_with = "config")]
+    pub path_or_config_key: Option<String>,
+
+    /// Display the path to your config file
+    #[arg(short, long)]
+    pub config: bool,
+
+    /// Specifies whether to use the path as a configuration key and skip checking your configuration file 🗝️
+    #[arg(short, long)]
+    pub use_path: bool,
+
+    /// Print out the file system tree 🌲
+    #[arg(short, long)]
+    pub tree: bool,
+
+    /// Recursively scan all items within all subfolders. Defaults to false 📁
+    #[arg(short)]
+    pub recursive: bool,
+
+    /// Whether to delete hidden files and folders. Defaults to false 🕵️
+    #[arg(short)]
+    pub delete_hidden: bool,
+
+    /// Automatically approve the deletion request ✅
+    #[arg(short)]
+    pub yes: bool,
+
+    /// Print the size of each file and folder within the deletion tree (requires --tree) 📦
+    #[arg(short, long, requires = "tree")]
+    pub size: bool,
+}


### PR DESCRIPTION
## PR Overview

Adds some useful helper functions for access my cleaning functions. This currently includes two functions:
1. `process_config`: Using a config, extract a list of files that should be scheduled for deletion, based on the settings specified by the user.
2. `print_deletion_tree`: A simple helper function that prints the directory tree if requested by the user.

Also adds a quick and dirty introductory CLI. This will be improved in a later PR.