### PR TITLE
Add `format_size` function

### DIFF
--- a/src/cleaning/mod.rs
+++ b/src/cleaning/mod.rs
@@ -27,11 +27,7 @@ pub fn track_files_for_deletion_in_given_config(
 
     match tracked_files {
         Ok((file_folder_queue, file_folder_metadata)) => {
-            let text_overview = deletion_overview.generate_text(
-                config,
-                file_folder_metadata,
-                &config.display_units,
-            );
+            let text_overview = deletion_overview.generate_text(config, file_folder_metadata);
             return Ok((text_overview, file_folder_queue));
         }
         Err(e) => {

--- a/src/cli_tools/cleaner_cli.rs
+++ b/src/cli_tools/cleaner_cli.rs
@@ -1,4 +1,3 @@
-use crate::configs::config::DataSizeUnit;
 use clap::{Parser, Subcommand};
 
 /// Cleans up folders based on a given path or configuration file.
@@ -20,10 +19,6 @@ pub struct DirectoryArgs {
     #[arg(required = true)]
     pub path_or_config_key: String,
 
-    /// Print out the file system tree 🌲
-    #[arg(short, long)]
-    pub tree: bool,
-
     /// Recursively scan all items within all subfolders 📁
     #[arg(short, default_value_t = false)]
     pub recursive: bool,
@@ -35,11 +30,6 @@ pub struct DirectoryArgs {
     /// Determines the path display format. If true, the path will be relative to the current directory.
     #[arg(long, aliases = ["relative", "relativepath"])]
     pub relative_path: bool,
-
-    #[arg(short, long, requires = "tree", verbatim_doc_comment, value_parser = clap::value_parser!(DataSizeUnit))]
-    /// Print the size of each file and folder within the deletion tree (requires --tree) 📦
-    /// Accepts a value to specify the size unit: Bytes, KB, MB, GB or TB.
-    pub size: Option<DataSizeUnit>,
 }
 
 #[derive(Parser)]
@@ -56,6 +46,10 @@ pub struct CleanArgs {
 pub struct SizeArgs {
     #[clap(flatten)]
     pub directory_args: DirectoryArgs,
+
+    /// Print out the file system tree 🌲
+    #[arg(short, long)]
+    pub tree: bool,
 }
 
 #[derive(Subcommand)]

--- a/src/cli_tools/mod.rs
+++ b/src/cli_tools/mod.rs
@@ -112,10 +112,6 @@ fn update_configs_with_cli_args(
             config.recursive = cleaner_args.recursive;
             config.delete_hidden = cleaner_args.include_hidden;
 
-            if let Some(size) = &cleaner_args.size {
-                config.display_units = size.clone();
-            }
-
             config
         })
         .collect()

--- a/src/logging/deletion_overview.rs
+++ b/src/logging/deletion_overview.rs
@@ -1,9 +1,7 @@
 use std::time::SystemTime;
 
-use crate::{
-    cleaning::track_files_for_deletion::DeletionMetaData,
-    configs::config::{DataSizeUnit, PathConfig},
-};
+use crate::utils::format_size;
+use crate::{cleaning::track_files_for_deletion::DeletionMetaData, configs::config::PathConfig};
 use chrono::{DateTime, Local};
 
 const DASHED_LINE: &str = "---------------------------------------------------------";
@@ -44,15 +42,11 @@ fn format_folder_path(config: &PathConfig) -> String {
     format!("{}: {:?}", bold("Folder path"), config.directory.display())
 }
 
-fn format_total_size(total_size: u64, unit: &DataSizeUnit) -> String {
-    format!(
-        "{}: {}",
-        bold("Total folder size"),
-        unit.display_total_size(total_size)
-    )
+fn format_total_size(total_size: u64) -> String {
+    format!("{}: {}", bold("Total folder size"), format_size(total_size))
 }
 
-fn format_deletion_size(deletion_metadata: &DeletionMetaData, unit: &DataSizeUnit) -> String {
+fn format_deletion_size(deletion_metadata: &DeletionMetaData) -> String {
     let file_directory_count_text = format!(
         "{} files, {} directories",
         deletion_metadata.file_count, deletion_metadata.dir_count
@@ -61,20 +55,20 @@ fn format_deletion_size(deletion_metadata: &DeletionMetaData, unit: &DataSizeUni
         "{}: {} - {}",
         bold("Data scheduled for deletion"),
         file_directory_count_text,
-        bold(&unit.display_total_size(deletion_metadata.deletion_size)),
+        bold(&format_size(deletion_metadata.deletion_size)),
     )
 }
 
-fn format_file_folder_counts(deletion_metadata: &DeletionMetaData, unit: &DataSizeUnit) -> String {
+fn format_file_folder_counts(deletion_metadata: &DeletionMetaData) -> String {
     let file_directory_count_text = format!(
         "{} files, {} directories",
         deletion_metadata.file_count, deletion_metadata.dir_count
     );
     format!(
         "{}: {} - {}",
-        bold("Total Size of files and directories"),
+        bold("Total size of files and directories"),
         file_directory_count_text,
-        bold(&unit.display_total_size(deletion_metadata.deletion_size)),
+        bold(&format_size(deletion_metadata.deletion_size)),
     )
 }
 
@@ -113,15 +107,14 @@ fn format_extensions(config: &PathConfig) -> Vec<String> {
 pub fn generate_deletion_overview_text(
     config: &PathConfig, // Assume this is the correct reference to PathConfig
     deletion_metadata: DeletionMetaData,
-    unit: &DataSizeUnit,
 ) -> String {
     let mut deletion_overview: Vec<String> = vec![];
     deletion_overview.extend(deletion_overview_text());
 
     // Log folder metadata
     deletion_overview.push(format_folder_path(config));
-    deletion_overview.push(format_total_size(deletion_metadata.folder_size, unit));
-    deletion_overview.push(format_deletion_size(&deletion_metadata, unit));
+    deletion_overview.push(format_total_size(deletion_metadata.folder_size));
+    deletion_overview.push(format_deletion_size(&deletion_metadata));
     deletion_overview.push(format_last_modified(deletion_metadata.last_modified_time));
     deletion_overview.extend(format_extensions(config));
     // Generate warning before asking for deletion confirmation
@@ -134,14 +127,13 @@ pub fn generate_deletion_overview_text(
 pub fn generate_size_overview_text(
     config: &PathConfig, // Assume this is the correct reference to PathConfig
     metadata: DeletionMetaData,
-    unit: &DataSizeUnit,
 ) -> String {
     let mut size_overview: Vec<String> = vec![];
     size_overview.extend(folder_size_overview_text());
 
     // Log folder metadata
     size_overview.push(format_folder_path(config));
-    size_overview.push(format_file_folder_counts(&metadata, unit));
+    size_overview.push(format_file_folder_counts(&metadata));
     size_overview.push(format_last_modified(metadata.last_modified_time));
     size_overview.extend(format_extensions(config));
 

--- a/src/logging/folder_tree_helpers.rs
+++ b/src/logging/folder_tree_helpers.rs
@@ -1,32 +1,17 @@
-use crate::configs::config::DataSizeUnit;
 use std::{fmt, path::PathBuf};
 
-// TODO: Implement 'LastModified' and 'DateCreated' suffixes
-#[derive(Debug, Clone)]
-pub enum TreeSuffix {
-    FileSizeDisplay(DataSizeUnit, u64),
-}
-
-impl TreeSuffix {
-    pub fn get_suffix_str(&self) -> String {
-        match *self {
-            TreeSuffix::FileSizeDisplay(ref display_unit, size) => {
-                format!(" - \x1b[1m{}\x1b[0m", display_unit.display_total_size(size))
-            }
-        }
-    }
-}
+use crate::utils::format_size;
 
 pub struct DirTreeOptions {
     pub display_files: bool,
-    pub tree_suffix: Option<TreeSuffix>,
+    pub file_size: Option<u64>,
 }
 
 impl Default for DirTreeOptions {
     fn default() -> Self {
         DirTreeOptions {
             display_files: true,
-            tree_suffix: None,
+            file_size: None,
         }
     }
 }
@@ -42,10 +27,13 @@ impl DirTreeOptions {
     }
 
     pub fn get_tree_suffix_str(&self) -> String {
-        // Default to empty string if no suffix is supplied
-        self.tree_suffix
-            .as_ref()
-            .map_or(String::new(), |suffix| suffix.get_suffix_str())
+        match self.file_size {
+            Some(size) => {
+                format!(" - \x1b[1m{}\x1b[0m", format_size(size))
+            }
+            // Default to empty string if no suffix is supplied
+            None => String::new(),
+        }
     }
 }
 
@@ -110,11 +98,11 @@ mod tests {
     fn test_skip_leaf_with_directory_regardless_of_display_files() {
         let options_with_true = DirTreeOptions {
             display_files: true,
-            tree_suffix: None,
+            file_size: None,
         };
         let options_with_false = DirTreeOptions {
             display_files: false,
-            tree_suffix: None,
+            file_size: None,
         };
 
         let directory_path = PathBuf::from("some_directory");
@@ -126,7 +114,7 @@ mod tests {
     fn test_get_tree_suffix_str_with_no_suffix() {
         let options = DirTreeOptions {
             display_files: true,
-            tree_suffix: None,
+            file_size: None,
         };
 
         assert_eq!(options.get_tree_suffix_str(), String::new());
@@ -136,12 +124,12 @@ mod tests {
     fn test_get_tree_suffix_str_with_suffix() {
         let options = DirTreeOptions {
             display_files: true,
-            tree_suffix: Some(TreeSuffix::FileSizeDisplay(DataSizeUnit::MB, 1024)),
+            file_size: Some(1024),
         };
 
         assert_eq!(
             options.get_tree_suffix_str(),
-            format!(" - \x1b[1m{}\x1b[0m", "0.00 MB")
+            format!(" - \x1b[1m{}\x1b[0m", "1.00 MB")
         );
     }
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -2,10 +2,7 @@ mod deletion_overview;
 pub mod folder_tree_helpers;
 pub mod process_directory_tree;
 
-use crate::{
-    cleaning::track_files_for_deletion::DeletionMetaData,
-    configs::config::{DataSizeUnit, PathConfig},
-};
+use crate::{cleaning::track_files_for_deletion::DeletionMetaData, configs::config::PathConfig};
 use deletion_overview::{generate_deletion_overview_text, generate_size_overview_text};
 use folder_tree_helpers::DirTreeOptions;
 use process_directory_tree::{process_folder_tree_stack, FileSystemStack};
@@ -20,13 +17,12 @@ impl TextOverviewType {
         &self,
         config: &PathConfig,
         deletion_metadata: DeletionMetaData,
-        unit: &DataSizeUnit,
     ) -> String {
         match self {
             TextOverviewType::Deletion => {
-                generate_deletion_overview_text(config, deletion_metadata, unit)
+                generate_deletion_overview_text(config, deletion_metadata)
             }
-            TextOverviewType::Size => generate_size_overview_text(config, deletion_metadata, unit),
+            TextOverviewType::Size => generate_size_overview_text(config, deletion_metadata),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,3 +27,43 @@ pub fn is_hidden_file(path: &PathBuf) -> bool {
         .map(|s| s.starts_with('.'))
         .unwrap_or(false)
 }
+
+pub fn format_size(bytes: u64) -> String {
+    let units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+    let mut bytes = bytes as f64;
+
+    for unit in units.iter() {
+        if bytes < 1024.0 {
+            return format!("{:.2} {}", bytes, unit);
+        }
+        bytes /= 1024.0;
+    }
+
+    format!("{:.2} {}", bytes, units.last().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_size_various() {
+        let test_cases = vec![
+            (500, "500.00 B"),
+            (1024, "1.00 KiB"),
+            (1536, "1.50 KiB"),
+            (1048576, "1.00 MiB"),
+            (1572864, "1.50 MiB"),
+            (1073741824, "1.00 GiB"),
+            (1610612736, "1.50 GiB"),
+            (1099511627776, "1.00 TiB"),
+            (1649267441664, "1.50 TiB"),
+            (1125899906842624, "1.00 PiB"),
+            (1152921504606846976, "1.00 EiB"),
+        ];
+
+        for (bytes, expected) in test_cases {
+            assert_eq!(format_size(bytes), expected, "Failed at {} bytes", bytes);
+        }
+    }
+}


### PR DESCRIPTION
- Change code to use `format_size` which will automatically detect and format file sizes
- Remove `DataSizeUnit` logic which was overly cumbersome and unnecessary
- 