### PR TITLE
Refactor format_size function to use KB, MB, GB, etc. instead of KiB,…

### DIFF
--- a/src/logging/folder_tree_helpers.rs
+++ b/src/logging/folder_tree_helpers.rs
@@ -129,7 +129,7 @@ mod tests {
 
         assert_eq!(
             options.get_tree_suffix_str(),
-            format!(" - \x1b[1m{}\x1b[0m", "1.00 MB")
+            format!(" - \x1b[1m{}\x1b[0m", "1.00 KB")
         );
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,4 @@
 use core::panic;
-use std::fs;
 use std::path::PathBuf;
 
 pub fn check_root_folder_exists(root_folder: &str) {
@@ -11,16 +10,6 @@ pub fn check_root_folder_exists(root_folder: &str) {
     }
 }
 
-pub fn get_metadata_or_panic(path: &PathBuf) -> fs::Metadata {
-    match fs::metadata(&path) {
-        Ok(metadata) => metadata,
-        Err(e) => {
-            eprintln!("Error scanning folder: {}", e);
-            panic!("Failed to retrieve metadata for {:?}", path);
-        }
-    }
-}
-
 pub fn is_hidden_file(path: &PathBuf) -> bool {
     path.file_name()
         .and_then(|n| n.to_str())
@@ -29,7 +18,7 @@ pub fn is_hidden_file(path: &PathBuf) -> bool {
 }
 
 pub fn format_size(bytes: u64) -> String {
-    let units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+    let units = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
     let mut bytes = bytes as f64;
 
     for unit in units.iter() {
@@ -50,16 +39,16 @@ mod tests {
     fn test_format_size_various() {
         let test_cases = vec![
             (500, "500.00 B"),
-            (1024, "1.00 KiB"),
-            (1536, "1.50 KiB"),
-            (1048576, "1.00 MiB"),
-            (1572864, "1.50 MiB"),
-            (1073741824, "1.00 GiB"),
-            (1610612736, "1.50 GiB"),
-            (1099511627776, "1.00 TiB"),
-            (1649267441664, "1.50 TiB"),
-            (1125899906842624, "1.00 PiB"),
-            (1152921504606846976, "1.00 EiB"),
+            (1024, "1.00 KB"),
+            (1536, "1.50 KB"),
+            (1048576, "1.00 MB"),
+            (1572864, "1.50 MB"),
+            (1073741824, "1.00 GB"),
+            (1610612736, "1.50 GB"),
+            (1099511627776, "1.00 TB"),
+            (1649267441664, "1.50 TB"),
+            (1125899906842624, "1.00 PB"),
+            (1152921504606846976, "1.00 EB"),
         ];
 
         for (bytes, expected) in test_cases {


### PR DESCRIPTION
… MiB, GiB, etc.